### PR TITLE
Fix for undefined LocalPackagesRepo variable

### DIFF
--- a/src/Composer/StudioPlugin.php
+++ b/src/Composer/StudioPlugin.php
@@ -85,7 +85,7 @@ class StudioPlugin implements PluginInterface, EventSubscriberInterface
             }
 
             $installationManager->getInstaller($original->getType())->uninstall($installed, $original);
-            $installationManager->getInstaller($package->getType())->install($LocalPackagesRepo, $package);
+            $installationManager->getInstaller($package->getType())->install($studioRepo, $package);
         }
 
         $studioRepo->write();


### PR DESCRIPTION
`$LocalPackagesRepo` isn't actually set which is causing `composer update` to fail. 

```
[Studio] Loading package my/package
  - Removing my/package (v1.1)

[ErrorException]
  Undefined variable: LocalPackagesRepo
```

After settings this to `$studioRepo`, we get the expected output.

```
[Studio] Loading package my/package
  - Removing my/package (v1.1)
  - Installing my/package (dev-master): Symlinking from vendor-dev/my/package
```